### PR TITLE
fix ios font scaling

### DIFF
--- a/_sass/_jamescuzella-screen.scss
+++ b/_sass/_jamescuzella-screen.scss
@@ -11,6 +11,7 @@ footer, header, hgroup, menu, nav, section {
 body {
 	line-height: 1rem;
 	-webkit-text-size-adjust: none; /* Fix font scaling bug observed on iOS 15.7 */
+	-webkit-font-smoothing: subpixel-antialiased; /* Avoid blurry fonts (especially with position: fixed) */
 }
 ol, ul {
 	list-style: none;

--- a/_sass/_jamescuzella-screen.scss
+++ b/_sass/_jamescuzella-screen.scss
@@ -10,6 +10,7 @@ footer, header, hgroup, menu, nav, section {
 }
 body {
 	line-height: 1rem;
+	-webkit-text-size-adjust: none; /* Fix font scaling bug observed on iOS 15.7 */
 }
 ol, ul {
 	list-style: none;


### PR DESCRIPTION
- **style: Fix font rem scaling bug on iOS 15.7 / Safari 15.6**
- **style: Declaratively set Safari/WebKit font-smoothing to subpixel-antialiased**
