### PR TITLE
style cleanup

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,6 @@ kramdown:
 webrick:
   headers:
     Access-Control-Allow-Origin: "*" # Allows requests from any origin
-    Access-Control-Allow-Origin: "http://localhost:4000" # Allows requests from a specific origin
     Access-Control-Allow-Methods: "GET, POST, PUT, DELETE, OPTIONS"
     Access-Control-Allow-Headers: "Content-Type, Authorization"
 postcss:

--- a/_layouts/cv-textsize-js.html
+++ b/_layouts/cv-textsize-js.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en" xml:lang="en">
 <head>
   <meta charset=utf-8 />
   <meta name="viewport" content="width=device-width initial-scale=1.0" />

--- a/_layouts/cv.html
+++ b/_layouts/cv.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en" xml:lang="en">
 <head>
   <meta charset=utf-8 />
   <meta name="viewport" content="width=device-width initial-scale=1.0" />

--- a/_layouts/cv.html
+++ b/_layouts/cv.html
@@ -9,7 +9,6 @@
   <link rel="preload" as="font" type="font/woff2" href="{{ 'assets/fonts/JetBrainsMonoNerdFontPropo-Regular.woff2' | relative_url }}" media="not all and (prefers-reduced-data)" crossorigin/>
   <link rel="preload" as="font" type="font/woff2" href="{{ 'assets/fonts/JetBrainsMonoNerdFontMono-Regular.woff2' | relative_url }}" crossorigin/>
   <link rel="preload" as="script" href="https://cdn.jsdelivr.net/npm/css-prefers-color-scheme@10.0.0/dist/browser-global.js" media="screen" crossorigin="anonymous"/>
-  <!-- <link rel="preload" as="font" type="font/woff2" href="{{ 'assets/fonts/JetBrainsMonoNerdFontMono-ExtraBold.woff2' | relative_url }}" crossorigin/> -->
 
   <link href="{{ 'assets/css/screen.css' | relative_url }}" type="text/css" rel="stylesheet" media="screen"/>
   <link href="{{ 'assets/css/print.css'  | relative_url }}" type="text/css" rel="stylesheet" media="print"/>

--- a/_sass/_jamescuzella-screen.scss
+++ b/_sass/_jamescuzella-screen.scss
@@ -109,15 +109,18 @@ table {
 	src: url("../fonts/JetBrainsMonoNerdFontMono-Regular.woff2") format('woff2'),
 		 url("../fonts/JetBrainsMonoNerdFontMono-Regular.ttf") format('truetype');
 }
-/* @font-face {
-	font-family: 'JetBrainsMono Nerd Font Mono';
-	font-style: normal;
-	font-weight: 800;
-	font-stretch: 100%;
-	font-display: swap;
-	src: url("../fonts/JetBrainsMonoNerdFontMono-ExtraBold.woff2") format('woff2'),
-		 url("../fonts/JetBrainsMonoNerdFontMono-ExtraBold.ttf") format('truetype');
-} */
+/* Disabled / Unused ExtraBold font-weight variant */
+@media not all and (prefers-reduced-data: no-preference) {
+	@font-face {
+		font-family: 'JetBrainsMono Nerd Font Mono';
+		font-style: normal;
+		font-weight: 800;
+		font-stretch: 100%;
+		font-display: swap;
+		src: url("../fonts/JetBrainsMonoNerdFontMono-ExtraBold.woff2") format('woff2'),
+			 url("../fonts/JetBrainsMonoNerdFontMono-ExtraBold.ttf") format('truetype');
+	}
+}
 
 /* NOSONAR css:S4654 */
 @font-feature-values "Noto Sans Display" {

--- a/_sass/_jamescuzella-screen.scss
+++ b/_sass/_jamescuzella-screen.scss
@@ -18,11 +18,9 @@ ol, ul {
 }
 blockquote, q {
 	quotes: none;
-}
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+	&:before, &:after {
+		content: none;
+	}
 }
 table {
 	border-collapse: collapse;

--- a/_sass/_jamescuzella-screen.scss
+++ b/_sass/_jamescuzella-screen.scss
@@ -290,8 +290,6 @@ ul > li > ul > li:before {
 		/* Standard UTF-8 U+25CB 'White Circle' ○ */
 		content: '○';
 		font-family: var(--font-family-li-bullet-system-fallback);
-		/* letter-spacing: 1.4px;
-		word-spacing: 2.5px; */
 		letter-spacing: 0.028125rem; /* 0.45 px @ 1rem = 16px */
 		word-spacing: 0.546875rem; /* 8.75 px @ 1rem = 16px */
 	}

--- a/_sass/_jamescuzella-screen.scss
+++ b/_sass/_jamescuzella-screen.scss
@@ -549,10 +549,6 @@ a:focus-visible {
 	}
 }
 
-#skills > * {
-	position: relative;
-}
-
 #skills > p {
 	width: var(--align-guide-main-width);
 	margin-left: unset;

--- a/_sass/_jamescuzella-screen.scss
+++ b/_sass/_jamescuzella-screen.scss
@@ -1686,15 +1686,13 @@ strong {
 }
 
 @media (prefers-reduced-motion: reduce) {
-	* {
-		/* Very short durations means JavaScript that relies on events still works */
-		animation-duration: 0.001ms !important;
-		animation-iteration-count: 1 !important;
-		transition-duration: 0.001ms !important;
-	}
 	a:hover {
 		text-decoration: none;
 		filter: none;
 		font-weight: bolder;
+		/* Very short durations means JavaScript that relies on events still works */
+		animation-duration: 0.001ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.001ms !important;
 	}
 }


### PR DESCRIPTION
- **style: Cleanup commented & unused bullet font matching spacing**
- **style: Combine :{before,after} selectors via nesting & rm duplicate content prop**
- **style: Uncomment but disable JetBrainsMonoNerdFontMono-ExtraBold**
- **style: Remove commented preload for JetBrainsMonoNerdFontMono-ExtraBold**
- **_layouts/*: Add "lang" & "xml:lang" to root html element**
- **jekyll: Cleanup duplicate CORS header config**
- **style: Remove redundant skills > * wildcard selector**
- **style: Avoid * wildcard selector for prefers-reduced-motion a:hover animations**
